### PR TITLE
bugfix: send DataParallel model to device

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/main.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/main.py
@@ -89,7 +89,7 @@ def setup_device(
     log.info(f'Using devices {target_devices} of available devices {available_devices}')
     device = torch.device(f'cuda:{target_devices[0]}')
     if len(target_devices) > 1:
-        model = nn.DataParallel(model, device_ids=target_devices)
+        model = nn.DataParallel(model, device_ids=target_devices).to(device)
     else:
         model = model.to(device)
     return model, device


### PR DESCRIPTION
Hi,
nice work! 
I had issues with running the script on multi gpus. This fixed it.

Regards

P.S.: One could think that just using the nn.DataParallel model will satisfy both cases, one or multiple gpus. What do you think?!